### PR TITLE
Direct users to the official ammap package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+**Note**: I created this package because there wasn't an officially supported
+one provided by amcharts. Happily, that is no longer the case and you should
+instead use the official package found here https://github.com/amcharts/ammap3
+
 # bower-ammap
 
 This repo is for distribution on `bower`. Can be found on


### PR DESCRIPTION
Why:

I created this package because there wasn't an officially supported one
provided by amcharts. Happily, that is no longer the case and users
should instead use the official package

This PR:

Adds a note at the top of the readme to direct users to use the
officially supported ammap bower package.
